### PR TITLE
Ignore debug symbols in Mach-O files

### DIFF
--- a/version/exe.go
+++ b/version/exe.go
@@ -288,7 +288,13 @@ func (x *machoExe) ReadData(addr, size uint64) ([]byte, error) {
 func (x *machoExe) Symbols() ([]sym, error) {
 	var out []sym
 	for _, s := range x.f.Symtab.Syms {
-		out = append(out, sym{s.Name, s.Value, 0})
+		if (s.Type & 0xe0) != 0 {
+			// Symbol type with any of the bits in 0xe0 set are debugging symbols.
+			// We won't be able to use this kind of entry to read the symbol's value,
+			// so ignore it.
+			continue
+		}
+			out = append(out, sym{s.Name, s.Value, 0})
 	}
 	return out, nil
 }


### PR DESCRIPTION
My team has encountered an issue where `goversion` can no longer
recognize our builds (see issue #12) due to a symbolic debugging entry
for `_runtime.buildVersion`.

If we omit such entries from the symbol list before looking for
`_runtime.BuildVersion`, then `goversion` works for our builds once
again.